### PR TITLE
Racket,serde: add get-rpc-checksum (racket-9.1-2)

### DIFF
--- a/Racket/noise-serde-doc/noise-manual.scrbl
+++ b/Racket/noise-serde-doc/noise-manual.scrbl
@@ -287,6 +287,22 @@ ids to handler procedures.
   Returns a procedure that stops the server when applied.
 }
 
+@defproc[(get-rpc-checksum) (-> string?)]{
+  Returns a SHA1 checksum in hex format representing the hashed names of
+  all defined RPCs at the moment the procedure is called. No new RPCs
+  may be defined after this procedure is called.
+
+  You can use this procedure to ensure that a generated backend file
+  matches the compiled application.
+
+  @examples[
+    #:eval ev
+    (get-rpc-checksum)
+  ]
+
+  @history[#:added "0.12"]
+}
+
 
 @section[#:tag "callouts"]{Callouts}
 @defmodule[noise/unsafe/callout]

--- a/Racket/noise-serde-lib/backend.rkt
+++ b/Racket/noise-serde-lib/backend.rkt
@@ -10,6 +10,7 @@
          "unsafe/callout.rkt")
 
 (provide
+ get-rpc-checksum
  define-callout
  define-rpc
  serve)

--- a/Racket/noise-serde-lib/codegen.rkt
+++ b/Racket/noise-serde-lib/codegen.rkt
@@ -255,7 +255,12 @@
 
 (module+ main
   (require racket/cmdline)
+  (define mode 'write)
   (command-line
+   #:once-any
+   [("--checksum")
+    "generate an RPC checksum"
+    (set! mode 'checksum)]
    #:once-each
    [("--no-backend")
     "turn off backend code generation"
@@ -263,4 +268,11 @@
    #:args [modpath]
    (parameterize ([current-output-port (current-error-port)])
      (dynamic-require modpath #f)))
-  (write-Swift-code))
+  (case mode
+    [(checksum)
+     (displayln (get-rpc-checksum))]
+    [(write)
+     (write-Swift-code)]
+    [else
+     (eprintf "error: invalid mode~n")
+     (exit 1)]))

--- a/Racket/noise-serde-lib/info.rkt
+++ b/Racket/noise-serde-lib/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 
 (define license 'BSD-3-Clause)
-(define version "0.11")
+(define version "0.12")
 (define collection "noise")
 (define deps '("base"
                "threading-lib"))

--- a/Racket/noise-serde-lib/private/backend.rkt
+++ b/Racket/noise-serde-lib/private/backend.rkt
@@ -3,12 +3,16 @@
 (require (for-syntax racket/base
                      syntax/parse/pre
                      "common.rkt")
+         file/sha1
+         racket/match
+         racket/port
          "sequencer.rkt"
          "serde.rkt")
 
 (provide
  define-rpc
 
+ get-rpc-checksum
  get-rpc-infos
  (struct-out rpc-arg)
  (struct-out rpc-info))
@@ -50,3 +54,15 @@
          (save-rpc-info! info)
          #,(when (eq? (syntax-local-context) 'module)
              #'(module+ rpc (provide name))))]))
+
+(define (get-rpc-checksum)
+  (bytes->hex-string
+   (sha1-bytes
+    (call-with-output-bytes
+     (lambda (out)
+       (define rpc-infos (get-rpc-infos))
+       (define sorted-rpc-ids (sort (hash-keys rpc-infos) <))
+       (for ([id (in-list sorted-rpc-ids)])
+         (match-define (rpc-info _ name _ _ _)
+           (hash-ref rpc-infos id))
+         (displayln name out)))))))

--- a/Template/Makefile
+++ b/Template/Makefile
@@ -22,7 +22,7 @@ clean:
 ${RKT_MAIN_ZO}: ${RKT_FILES}
 	raco make -j 16 -v ${RKT_SRC}/main.rkt
 
-${CORE_ZO}: ${RKT_MAIN_ZO}
+${CORE_ZO}: ${RKT_MAIN_ZO} ${RKT_SRC}/Backend.sha1
 	mkdir -p ${RESOURCES_PATH}
 	rm -fr ${RUNTIME_PATH}
 	raco ctool \
@@ -32,6 +32,9 @@ ${CORE_ZO}: ${RKT_MAIN_ZO}
 
 ${APP_SRC}/Backend.swift: ${CORE_ZO}
 	raco noise-serde-codegen ${RKT_SRC}/main.rkt > $@
+
+${RKT_SRC}/Backend.sha1: ${RKT_FILES}
+	./bin/pbraco noise-serde-codegen --checksum ${RKT_SRC}/main.rkt > $@
 
 ${MANUAL_PATH}/index.html: manual/*.scrbl
 	raco scribble --html --dest ${MANUAL_PATH} +m manual/index.scrbl


### PR DESCRIPTION
## Summary
- Cherry-pick of a5be102 "Racket,serde: add get-rpc-checksum" onto the racket-9.1-2 branch so projects using the 9.1-2 pbracket snapshot (e.g. Podcatcher master, which now requires `get-rpc-checksum` at boot) can build.

## Test plan
- [x] `PBRACKET_ROOT=~/sandbox/racket-pb make` on Podcatcher master with Noise on this branch — Racket core rebuilds, codegen regenerates `Backend.swift`, and the app launches in the simulator.