### PR TITLE
Package: scope NoiseTest deps to iOS+macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,8 +56,8 @@ let package = Package(
     .testTarget(
       name: "NoiseTest",
       dependencies: [
-        "Noise",
-        "NoiseBackend",
+        .target(name: "Noise", condition: .when(platforms: [.iOS, .macOS])),
+        .target(name: "NoiseBackend", condition: .when(platforms: [.iOS, .macOS])),
         "NoiseSerde",
       ],
       resources: [


### PR DESCRIPTION
## Summary

Tuist 4.186.2's graph linter rejects workspaces where a target's supported platforms exceed its dependencies'. When Noise is consumed via Tuist by a project that also targets watchOS (e.g. Podcatcher), \`NoiseTest\` gets widened to include watchOS, but its iOS+macOS-only deps trigger:

> Target NoiseTest which depends on NoiseBackend does not support the required platforms: watchos. The dependency on NoiseBackend must have a dependency condition constraining to at most: ios.

Adding \`condition: .when(platforms: [.iOS, .macOS])\` to the dep edges narrows them to match what the Package declares, which is what Tuist's lint asks for. No behaviour change for pure-SwiftPM consumers.

Failing run in Podcatcher: https://github.com/Bogdanp/Podcatcher/actions/runs/26021778734/job/76488858516
Verified locally with Tuist 4.186.2: \`tuist generate\` succeeds with this patch and fails on master without it.

## Test plan

- [x] \`tuist generate\` succeeds in Podcatcher with Tuist 4.186.2 after this patch (with \`NOISE_PATH\` pointing at this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)